### PR TITLE
add:userIDが必要な所にトークン処理を追加

### DIFF
--- a/src/controller/user_controller.go
+++ b/src/controller/user_controller.go
@@ -2,9 +2,11 @@ package controller
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kajiLabTeam/hacku-2023-back/integrations"
 	"github.com/kajiLabTeam/hacku-2023-back/model"
 )
 
@@ -17,6 +19,14 @@ type Short struct {
 }
 
 func GetProfile(c *gin.Context) {
+	authHeader := c.Request.Header.Get("Authorization")
+	header := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := integrations.GetUserByID(header)
+	if err != nil {
+		print(err)
+	}
+	u_id := token.UID
+
 	type Achievement struct {
 		Name string `json:"name"`
 		Link string `json:"link"`
@@ -36,8 +46,6 @@ func GetProfile(c *gin.Context) {
 		Achievements []Achievement `json:"achievements"`
 		Report       Report        `json:"report"`
 	}
-	//本来はトークンから取得
-	u_id := "0000000000000000000000000001"
 	var a = []Achievement{}
 	colors := []string{
 		"245, 101, 101, 1",
@@ -92,8 +100,13 @@ func GetProfile(c *gin.Context) {
 
 func GetBrowsingHistory(c *gin.Context) {
 	page := c.DefaultQuery("page", "")
-	//本来はトークンから取得
-	u_id := "0000000000000000000000000001"
+	authHeader := c.Request.Header.Get("Authorization")
+	header := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := integrations.GetUserByID(header)
+	if err != nil {
+		print(err)
+	}
+	u_id := token.UID
 
 	var result []Short
 	bh := model.Get100BrowsingHistoryByUserID(u_id, page)
@@ -117,9 +130,13 @@ func GetBrowsingHistory(c *gin.Context) {
 
 func GetPostingHistory(c *gin.Context) {
 	page := c.DefaultQuery("page", "")
-	//本来はトークンから取得
-	u_id := "0000000000000000000000000001"
-
+	authHeader := c.Request.Header.Get("Authorization")
+	header := strings.TrimPrefix(authHeader, "Bearer ")
+	token, err := integrations.GetUserByID(header)
+	if err != nil {
+		print(err)
+	}
+	u_id := token.UID
 	var result []Short
 	ph := model.Get100ShortByUserID(u_id, page)
 	for i := 0; i < len(ph); i++ {

--- a/src/integrations/storage.go
+++ b/src/integrations/storage.go
@@ -1,5 +1,6 @@
 package integrations
 
+/*
 import (
 	"context"
 	"fmt"
@@ -68,3 +69,4 @@ func GetFileUrl(rp string) (string, error) {
 	return u, nil
 
 }
+*/

--- a/src/model/insert_testdata.go
+++ b/src/model/insert_testdata.go
@@ -4,7 +4,7 @@ import "time"
 
 func InsertTestData() {
 	user := []User{
-		{ID: "0000000000000000000000000001", UserName: "mizutani"},
+		{ID: "cuidubv6Isgws8qba8oGGA0jd1i2", UserName: "mizutani"},
 		{ID: "0000000000000000000000000002", UserName: "shika"},
 		{ID: "0000000000000000000000000003", UserName: "hoge"},
 	}

--- a/src/model/short.go
+++ b/src/model/short.go
@@ -39,6 +39,15 @@ func GetShortByIDArray(id []int) []Short {
 	return s
 }
 
+func GetShortByTitle(title string) []Short {
+	s := []Short{}
+	result := db.Where("title LIKE ?", "%"+title+"%").Find(&s)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	return s
+}
+
 func Get100ShortByUserID(id string, page string) []Short {
 	s := []Short{}
 	offset, err := strconv.Atoi(page)
@@ -56,7 +65,7 @@ func Get100ShortByUserID(id string, page string) []Short {
 
 func GetRundumShort() []Short {
 	s := []Short{}
-	result := db.Order("RANDOM()").Limit(10).Find(&s)
+	result := db.Order("RAND()").Limit(10).Find(&s)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil
 	}

--- a/src/model/user.go
+++ b/src/model/user.go
@@ -17,7 +17,7 @@ type User struct {
 
 func GetUserByID(id string) *User {
 	u := User{}
-	result := db.First(&u, id)
+	result := db.First(&u, "id = ?", id)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil
 	}


### PR DESCRIPTION
仮のUserIDを置いていた場所にトークンを処理した UserIDを使用する処理を追加しました。
それに伴い
 - ユーザーがショートを見た時に閲覧履歴を保存
 - ショートに対してリアクションをしたかの確認
などの見ているユーザーを判別しないとできなかった処理を実装しました

またコードを見返していて改善できるところがあったので一部改善しました
※処理自体は変わっていません